### PR TITLE
feat(validators): add built-in validation rules

### DIFF
--- a/src/core/builders/create-form-validator.spec.ts
+++ b/src/core/builders/create-form-validator.spec.ts
@@ -1,5 +1,6 @@
 import { assert, IsExact } from "conditional-type-checks";
 
+import { validators } from "../../validators";
 import { FieldDescriptor } from "../types/field-descriptor";
 import { FormValidator } from "../types/form-validator";
 import { impl } from "../types/type-mapper-util";
@@ -604,5 +605,62 @@ describe("createFormValidator", () => {
     expect(onFieldValidationEnd).not.toHaveBeenCalledWith(
       expectField(Schema.arrayString)
     );
+  });
+
+  it("should cancel validation when optional rule is used", async () => {
+    const rule1 = jest.fn().mockReturnValue("ERR_1");
+    const rule2 = jest.fn().mockReturnValue("ERR_2");
+
+    const { validate } = createFormValidator(Schema, validate => [
+      validate({
+        field: Schema.string,
+        rules: () => [validators.optional(), rule1, rule2],
+      }),
+    ]);
+
+    const getValue = jest
+      .fn()
+      .mockReturnValueOnce("")
+      .mockReturnValueOnce("foo");
+
+    {
+      const result = await validate({ fields: [Schema.string], getValue });
+
+      expect(result).toEqual([
+        { field: Schema.arrayString.nth(0), error: null },
+      ]);
+      expect(rule1).not.toHaveBeenCalled();
+      expect(rule2).not.toHaveBeenCalled();
+    }
+
+    {
+      const result = await validate({ fields: [Schema.string], getValue });
+
+      expect(result).toEqual([
+        { field: Schema.arrayString.nth(0), error: "ERR_1" },
+      ]);
+      expect(rule1).toHaveBeenCalled();
+      expect(rule2).not.toHaveBeenCalled();
+    }
+  });
+
+  it("should re-throw any errors thrown by validation rules", async () => {
+    const error = new Error("test error");
+
+    const rule1 = jest.fn().mockReturnValue(null);
+    const rule2 = jest.fn().mockRejectedValue(error);
+
+    const { validate } = createFormValidator(Schema, validate => [
+      validate({
+        field: Schema.string,
+        rules: () => [rule1, rule2],
+      }),
+    ]);
+
+    const getValue = jest.fn().mockReturnValue("foo");
+
+    await expect(() =>
+      validate({ fields: [Schema.string], getValue })
+    ).rejects.toBe(error);
   });
 });

--- a/src/core/builders/create-form-validator.ts
+++ b/src/core/builders/create-form-validator.ts
@@ -84,10 +84,18 @@ export const createFormValidator = <Values extends object, Err>(
           onFieldValidationStart?.(field);
           return firstNonNullPromise(validators, v =>
             runValidationForField(v, value)
-          ).then(error => {
-            onFieldValidationEnd?.(field);
-            return { field, error };
-          });
+          )
+            .catch(err => {
+              if (err === true) {
+                return null; // optional validator edge-case
+              }
+              onFieldValidationEnd?.(field);
+              throw err;
+            })
+            .then(error => {
+              onFieldValidationEnd?.(field);
+              return { field, error };
+            });
         })
       );
     },
@@ -120,7 +128,13 @@ const runValidationForField = <Value, Err>(
     .validators([] as any)
     .filter(x => !isFalsy(x)) as Validator<Value, Err>[];
 
-  return firstNonNullPromise(rules, rule => Promise.resolve(rule(value)));
+  return firstNonNullPromise(rules, rule => {
+    try {
+      return Promise.resolve(rule(value));
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  });
 };
 
 const firstNonNullPromise = <T, V>(

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,7 @@
 export { createForm } from "./builders";
-export { useFormts } from "./hooks/use-formts";
+export { useFormts, FormtsOptions } from "./hooks/use-formts";
 
 export { FieldDecoder } from "./types/field-decoder";
 export { FieldDescriptor } from "./types/field-descriptor";
 export { FormSchema } from "./types/form-schema";
+export { FormValidator, Validator } from "./types/form-validator";

--- a/src/core/types/form-validator.ts
+++ b/src/core/types/form-validator.ts
@@ -13,11 +13,15 @@ import {
  *
  * @returns validation error of type `Err`, or `null` when field is valid
  */
-export type Validator<T, Err> = ValidatorSync<T, Err> | ValidatorAsync<T, Err>;
+export type Validator<T, Err> =
+  | Validator.Sync<T, Err>
+  | Validator.Async<T, Err>;
 
-export type ValidatorSync<T, Err> = (value: T) => Err | null;
+export namespace Validator {
+  export type Sync<T, Err> = (value: T) => Err | null;
 
-export type ValidatorAsync<T, Err> = (value: T) => Promise<Err | null>;
+  export type Async<T, Err> = (value: T) => Promise<Err | null>;
+}
 
 export type ValidationTrigger = "change" | "blur" | "submit";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./core";
+export * from "./validators";

--- a/src/utils/utility-types.ts
+++ b/src/utils/utility-types.ts
@@ -35,3 +35,13 @@ export type Falsy = null | undefined | false;
 export const isFalsy = (x: unknown): x is Falsy => {
   return x === null || x === undefined || x === false;
 };
+
+export type Primitive = string | number | boolean;
+
+export type WidenType<T> = [T] extends [string]
+  ? string
+  : [T] extends [number]
+  ? number
+  : [T] extends [boolean]
+  ? boolean
+  : T;

--- a/src/validators/base-errors.ts
+++ b/src/validators/base-errors.ts
@@ -1,0 +1,23 @@
+import { Primitive } from "../utils/utility-types";
+
+export type Required = { code: "required" };
+export type OneOf = { code: "oneOf"; allowedValues: Primitive[] };
+
+export type Integer = { code: "integer" };
+export type MinValue = { code: "minValue"; min: number };
+export type MaxValue = { code: "maxValue"; max: number };
+export type GreaterThan = { code: "greaterThan"; threshold: number };
+export type LesserThan = { code: "lesserThan"; threshold: number };
+
+export type Pattern = { code: "pattern"; regex: RegExp };
+export type HasSpecialChar = { code: "hasSpecialChar" };
+export type HasUpperCaseChar = { code: "hasUpperCaseChar" };
+export type HasLowerCaseChar = { code: "hasLowerCaseChar" };
+
+export type MinLength = { code: "minLength"; min: number };
+export type MaxLength = { code: "maxLength"; max: number };
+export type ExactLength = { code: "exactLength"; expected: number };
+
+export type ValidDate = { code: "validDate" };
+export type MinDate = { code: "minDate"; min: Date };
+export type MaxDate = { code: "maxDate"; max: Date };

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,0 +1,4 @@
+// TODO: tree-shaking compatible way of importing validators
+export * as validators from "./validators";
+
+export * as BaseErrors from "./base-errors";

--- a/src/validators/validators.spec.ts
+++ b/src/validators/validators.spec.ts
@@ -1,0 +1,384 @@
+import { assert, IsExact } from "conditional-type-checks";
+
+import * as validators from "./validators";
+
+const str = JSON.stringify;
+
+describe("validators", () => {
+  describe("withError", () => {
+    it("creates new validator with changed error", () => {
+      const original = (val: number) => (val == 42 ? null : ("ERR_A" as const));
+
+      const modified = validators.withError(original, "ERR_B" as const);
+
+      assert<IsExact<ReturnType<typeof modified>, "ERR_B" | null>>(true);
+      expect(modified(10)).toBe("ERR_B");
+      expect(modified(42)).toBe(null);
+    });
+  });
+
+  describe("required", () => {
+    [
+      { value: null, ok: false },
+      { value: undefined, ok: false },
+      { value: {}, ok: true },
+      { value: false, ok: false },
+      { value: true, ok: true },
+      { value: "", ok: false },
+      { value: " ", ok: true },
+      { value: "foo", ok: true },
+      { value: 0, ok: true },
+      { value: 42, ok: true },
+      { value: new Date(), ok: true },
+      { value: [], ok: true },
+    ].forEach(({ value, ok }) =>
+      it(`required()(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.required();
+
+        expect(validator(value)).toEqual(ok ? null : { code: "required" });
+      })
+    );
+  });
+
+  describe("optional", () => {
+    it("passes through non-empty values", () => {
+      const validator = validators.optional();
+
+      expect(validator("foo")).toBe(null);
+      expect(validator(true)).toBe(null);
+      expect(validator(0)).toBe(null);
+      expect(validator({})).toBe(null);
+      expect(validator([])).toBe(null);
+    });
+
+    it("throws special error to cause early return of validation for empty values", () => {
+      const validator = validators.optional();
+
+      try {
+        validator("");
+      } catch (err) {
+        expect(err).toBe(true);
+      }
+
+      try {
+        validator(null);
+      } catch (err) {
+        expect(err).toBe(true);
+      }
+
+      try {
+        validator(false);
+      } catch (err) {
+        expect(err).toBe(true);
+      }
+
+      expect.assertions(3);
+    });
+  });
+
+  describe("oneOf", () => {
+    [
+      { allowed: [], value: 42, ok: false },
+      { allowed: [42], value: 42, ok: true },
+      { allowed: [41, 43], value: 42, ok: false },
+      { allowed: [1, "2"], value: 1, ok: true },
+      { allowed: [1, "2"], value: 2, ok: false },
+      { allowed: [1, "2"], value: "1", ok: false },
+      { allowed: [1, "2"], value: "2", ok: true },
+      { allowed: ["A", "B", "C", "D"], value: "C", ok: true },
+      { allowed: ["A", "B", "C", "D"], value: "E", ok: false },
+    ].forEach(({ allowed, value, ok }) =>
+      it(`oneOf(${str(allowed)})(${str(value)}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.oneOf(...allowed);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "oneOf", allowedValues: allowed }
+        );
+      })
+    );
+  });
+
+  describe("integer", () => {
+    [
+      { value: "" as const, ok: false },
+      { value: 0, ok: true },
+      { value: -42, ok: true },
+      { value: 0.1, ok: false },
+      { value: Infinity, ok: false },
+      { value: NaN, ok: false },
+    ].forEach(({ value, ok }) =>
+      it(`integer()(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.integer();
+
+        expect(validator(value)).toEqual(ok ? null : { code: "integer" });
+      })
+    );
+  });
+
+  describe("minValue", () => {
+    [
+      { min: 10.5, value: "" as const, ok: false },
+      { min: 10.5, value: -20, ok: false },
+      { min: 10.5, value: 10.5, ok: true },
+      { min: 10.5, value: 42, ok: true },
+    ].forEach(({ min, value, ok }) =>
+      it(`minValue(${str(min)})(${str(value)}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.minValue(min);
+
+        expect(validator(value)).toEqual(ok ? null : { code: "minValue", min });
+      })
+    );
+  });
+
+  describe("maxValue", () => {
+    [
+      { max: -0.5, value: "" as const, ok: false },
+      { max: -0.5, value: -20, ok: true },
+      { max: -0.5, value: -0.5, ok: true },
+      { max: -0.5, value: 0, ok: false },
+      { max: -0.5, value: 42, ok: false },
+    ].forEach(({ max, value, ok }) =>
+      it(`maxValue(${str(max)})(${str(value)}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.maxValue(max);
+
+        expect(validator(value)).toEqual(ok ? null : { code: "maxValue", max });
+      })
+    );
+  });
+
+  describe("greaterThan", () => {
+    [
+      { threshold: 10.5, value: "" as const, ok: false },
+      { threshold: 10.5, value: -20, ok: false },
+      { threshold: 10.5, value: 10.5, ok: false },
+      { threshold: 10.5, value: 10.500001, ok: true },
+      { threshold: 10.5, value: 42, ok: true },
+    ].forEach(({ threshold, value, ok }) =>
+      it(`greaterThan(${str(threshold)})(${str(value)}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.greaterThan(threshold);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "greaterThan", threshold }
+        );
+      })
+    );
+  });
+
+  describe("lesserThan", () => {
+    [
+      { threshold: -0.5, value: "" as const, ok: false },
+      { threshold: -0.5, value: -20, ok: true },
+      { threshold: -0.5, value: -0.500001, ok: true },
+      { threshold: -0.5, value: -0.5, ok: false },
+      { threshold: -0.5, value: 0, ok: false },
+      { threshold: -0.5, value: 42, ok: false },
+    ].forEach(({ threshold, value, ok }) =>
+      it(`lesserThan(${str(threshold)})(${str(value)}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.lesserThan(threshold);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "lesserThan", threshold }
+        );
+      })
+    );
+  });
+
+  describe("pattern", () => {
+    const regex = /f(o)+bar/;
+
+    [
+      { value: "", ok: false },
+      { value: "foo", ok: false },
+      { value: "fobar", ok: true },
+      { value: "foobar", ok: true },
+      { value: "ffffoooobarrr", ok: true },
+    ].forEach(({ value, ok }) =>
+      it(`pattern(${regex})(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.pattern(regex);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "pattern", regex }
+        );
+      })
+    );
+  });
+
+  describe("hasUpperCaseChar", () => {
+    [
+      { value: "", ok: false },
+      { value: "foo", ok: false },
+      { value: "Foo", ok: true },
+      { value: "a a A", ok: true },
+      { value: "ABC", ok: true },
+    ].forEach(({ value, ok }) =>
+      it(`hasUpperCaseChar()(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.hasUpperCaseChar();
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "hasUpperCaseChar" }
+        );
+      })
+    );
+  });
+
+  describe("hasLowerCaseChar", () => {
+    [
+      { value: "", ok: false },
+      { value: "FOO", ok: false },
+      { value: "Foo", ok: true },
+    ].forEach(({ value, ok }) =>
+      it(`hasLowerCaseChar()(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.hasLowerCaseChar();
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "hasLowerCaseChar" }
+        );
+      })
+    );
+  });
+
+  describe("minLength", () => {
+    [
+      { min: 0, value: "", ok: true },
+      { min: 0, value: [], ok: true },
+      { min: 3, value: "", ok: false },
+      { min: 3, value: [], ok: false },
+      { min: 3, value: "foo", ok: true },
+      { min: 3, value: [1, 1, 1], ok: true },
+      { min: 3, value: "foobar", ok: true },
+      { min: 3, value: [1, 1, 1, 1, 1], ok: true },
+    ].forEach(({ min, value, ok }) =>
+      it(`minLength(${min})(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.minLength(min);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "minLength", min }
+        );
+      })
+    );
+  });
+
+  describe("maxLength", () => {
+    [
+      { max: 0, value: "", ok: true },
+      { max: 0, value: [], ok: true },
+      { max: 0, value: "a", ok: false },
+      { max: 0, value: [1], ok: false },
+      { max: 2, value: "", ok: true },
+      { max: 2, value: [], ok: true },
+      { max: 2, value: "a", ok: true },
+      { max: 2, value: [1], ok: true },
+      { max: 2, value: "ab", ok: true },
+      { max: 2, value: [1, 2], ok: true },
+      { max: 2, value: "abc", ok: false },
+      { max: 2, value: [1, 2, 3], ok: false },
+    ].forEach(({ max, value, ok }) =>
+      it(`maxLength(${max})(${str(value)}) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.maxLength(max);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "maxLength", max }
+        );
+      })
+    );
+  });
+
+  describe("exactLength", () => {
+    [
+      { expected: 0, value: "", ok: true },
+      { expected: 0, value: [], ok: true },
+      { expected: 0, value: "a", ok: false },
+      { expected: 0, value: [1], ok: false },
+      { expected: 2, value: "", ok: false },
+      { expected: 2, value: [], ok: false },
+      { expected: 2, value: "a", ok: false },
+      { expected: 2, value: [1], ok: false },
+      { expected: 2, value: "ab", ok: true },
+      { expected: 2, value: [1, 2], ok: true },
+      { expected: 2, value: "abc", ok: false },
+      { expected: 2, value: [1, 2, 3], ok: false },
+    ].forEach(({ expected, value, ok }) =>
+      it(`exactLength(${expected})(${str(value)}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.exactLength(expected);
+
+        expect(validator(value)).toEqual(
+          ok ? null : { code: "exactLength", expected }
+        );
+      })
+    );
+  });
+
+  describe("validDate", () => {
+    [
+      { value: new Date(), ok: true },
+      { value: new Date("2016-05-24T23:00:00"), ok: true },
+      { value: new Date("2016-13-24T23:00:00"), ok: false },
+      { value: new Date("huh?"), ok: false },
+      { value: null, ok: false },
+    ].forEach(({ value, ok }) =>
+      it(`validDate()(${value?.toDateString() ?? "null"}) -> ${
+        ok ? "OK" : "ERROR"
+      }`, () => {
+        const validator = validators.validDate();
+
+        expect(validator(value)).toEqual(ok ? null : { code: "validDate" });
+      })
+    );
+  });
+
+  describe("minDate", () => {
+    const min = new Date("2016-05-24T23:00:00");
+
+    [
+      { value: null, ok: false },
+      { value: new Date("huh?"), ok: false },
+      { value: new Date("2015-05-24T23:00:00"), ok: false },
+      { value: new Date("2016-05-24T22:59:59"), ok: false },
+      { value: new Date("2016-05-24T23:00:00"), ok: true },
+      { value: new Date("2016-05-24T23:01:00"), ok: true },
+      { value: new Date("2017-05-24T23:00:00"), ok: true },
+    ].forEach(({ value, ok }) =>
+      it(`minDate(${min.toDateString()})(${
+        value?.toDateString() ?? "null"
+      }) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.minDate(min);
+
+        expect(validator(value)).toEqual(ok ? null : { code: "minDate", min });
+      })
+    );
+  });
+
+  describe("maxDate", () => {
+    const max = new Date("2016-05-24T23:00:00");
+
+    [
+      { value: null, ok: false },
+      { value: new Date("huh?"), ok: false },
+      { value: new Date("2015-05-24T23:00:00"), ok: true },
+      { value: new Date("2016-05-24T22:59:59"), ok: true },
+      { value: new Date("2016-05-24T23:00:00"), ok: true },
+      { value: new Date("2016-05-24T23:01:00"), ok: false },
+      { value: new Date("2017-05-24T23:00:00"), ok: false },
+    ].forEach(({ value, ok }) =>
+      it(`maxDate(${max.toDateString()})(${
+        value?.toDateString() ?? "null"
+      }) -> ${ok ? "OK" : "ERROR"}`, () => {
+        const validator = validators.maxDate(max);
+
+        expect(validator(value)).toEqual(ok ? null : { code: "maxDate", max });
+      })
+    );
+  });
+});

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Validator } from "../core";
+import { Primitive, WidenType } from "../utils/utility-types";
+
+import * as BaseErrors from "./base-errors";
+
+// utils
+
+/**
+ * Creates new validator that is a wrapper around provided validator
+ * but returning different errors
+ *
+ * @param validator used to construct new validator
+ * @param error errors returned by the new validator
+ */
+export const withError = <T, Err1, Err2>(
+  validator: Validator.Sync<T, Err1>,
+  error: Err2
+): Validator.Sync<T, Err2> => val => (validator(val) == null ? null : error);
+
+// general
+
+/** Checks if field value is present */
+export const required = (): Validator.Sync<
+  unknown,
+  BaseErrors.Required
+> => val =>
+  val == null || val === "" || val === false ? { code: "required" } : null;
+
+/**
+ * Special validator that breaks validation chains early with no error, when field value is not present.
+ * This means that other validators do not have to handle empty value as edge case.
+ */
+export const optional = () => (val: unknown): null => {
+  const notPresent = required()(val) != null;
+
+  if (notPresent) {
+    throw true; // special way of breaking validation chain early
+  }
+  return null;
+};
+
+/** checks if value is one of provided values */
+export const oneOf = <V extends Primitive>(
+  ...allowedValues: V[]
+): Validator.Sync<WidenType<V>, BaseErrors.OneOf> => val =>
+  allowedValues.includes(val as V) ? null : { code: "oneOf", allowedValues };
+
+// numbers
+
+/** checks if value is integer number */
+export const integer = (): Validator.Sync<
+  number | "",
+  BaseErrors.Integer
+> => num => (Number.isInteger(num) ? null : { code: "integer" });
+
+/** checks number value against provided minimum */
+export const minValue = (
+  min: number
+): Validator.Sync<number | "", BaseErrors.MinValue> => num =>
+  num === "" || num < min ? { code: "minValue", min } : null;
+
+/** checks number value against provided maximum */
+export const maxValue = (
+  max: number
+): Validator.Sync<number | "", BaseErrors.MaxValue> => num =>
+  num === "" || num > max ? { code: "maxValue", max } : null;
+
+/** checks if value is a number greater than provided value */
+export const greaterThan = (
+  threshold: number
+): Validator.Sync<number | "", BaseErrors.GreaterThan> => num =>
+  num === "" || num <= threshold ? { code: "greaterThan", threshold } : null;
+
+/** checks if value is a number smaller than provided value */
+export const lesserThan = (
+  threshold: number
+): Validator.Sync<number | "", BaseErrors.LesserThan> => num =>
+  num === "" || num >= threshold ? { code: "lesserThan", threshold } : null;
+
+// strings
+
+/** checks pattern exists in string value using `RegExp.test` function */
+export const pattern = (
+  regex: RegExp
+): Validator.Sync<string, BaseErrors.Pattern> => string =>
+  regex.test(string) ? null : { code: "pattern", regex };
+
+/** checks if string value contains an uppercase character */
+export const hasUpperCaseChar = (): Validator.Sync<
+  string,
+  BaseErrors.HasUpperCaseChar
+> => (val: string) =>
+  /[A-Z]/.test(val) ? null : { code: "hasUpperCaseChar" as const };
+
+/** checks if string value contains an lowercase character */
+export const hasLowerCaseChar = (): Validator.Sync<
+  string,
+  BaseErrors.HasLowerCaseChar
+> => (val: string) =>
+  /[a-z]/.test(val) ? null : { code: "hasLowerCaseChar" as const };
+
+// strings or arrays
+
+/** checks length of string or array value against provided minimum */
+export const minLength = (
+  min: number
+): Validator.Sync<{ length: number }, BaseErrors.MinLength> => val =>
+  val.length < min ? { code: "minLength", min } : null;
+
+/** checks length of string or array value against provided maximum */
+export const maxLength = (
+  max: number
+): Validator.Sync<{ length: number }, BaseErrors.MaxLength> => val =>
+  val.length > max ? { code: "maxLength", max } : null;
+
+/** checks if length of string or array value is equal to expected */
+export const exactLength = (
+  expected: number
+): Validator.Sync<{ length: number }, BaseErrors.ExactLength> => val =>
+  val.length !== expected ? { code: "exactLength", expected } : null;
+
+// dates
+
+/** checks if date value is valid */
+export const validDate = (): Validator.Sync<
+  Date | null,
+  BaseErrors.ValidDate
+> => date =>
+  date == null || Number.isNaN(date.valueOf()) ? { code: "validDate" } : null;
+
+/** compares date value against provided minimum */
+export const minDate = (
+  min: Date
+): Validator.Sync<Date | null, BaseErrors.MinDate> => date =>
+  date == null || Number.isNaN(date.valueOf()) || date.valueOf() < min.valueOf()
+    ? { code: "minDate", min }
+    : null;
+
+/** compares date value against provided maximum */
+export const maxDate = (
+  max: Date
+): Validator.Sync<Date | null, BaseErrors.MaxDate> => date =>
+  date == null || Number.isNaN(date.valueOf()) || date.valueOf() > max.valueOf()
+    ? { code: "maxDate", max }
+    : null;


### PR DESCRIPTION
- export validation rules under validators namespace
- support early abort of field validation by throwing 'true' (for usage in `optional` validator)

closes #23 