### PR TITLE
docs(examples): setup codesandbox examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+# Formts examples
+
+Feel free to explore examples to learn more about the project. Each example
+contains link to `CodeSandbox` and some description.

--- a/examples/basic-forms/1-basic-form-naive/README.md
+++ b/examples/basic-forms/1-basic-form-naive/README.md
@@ -1,0 +1,14 @@
+# Basic Form Naive Example
+
+This is the simplest possible example of `Formts` usage
+
+### Notes:
+
+Using all hooks in root component will cause the whole form to rerender a lot
+and does not scale well for larger forms.
+
+See also: `basic-form-improved`
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/1-basic-form-naive)

--- a/examples/basic-forms/1-basic-form-naive/index.css
+++ b/examples/basic-forms/1-basic-form-naive/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/basic-forms/1-basic-form-naive/package.json
+++ b/examples/basic-forms/1-basic-form-naive/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/basic-form-naive",
+  "description": "This is the simplest possible example of Formts usage",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/basic-forms/1-basic-form-naive/src/example.tsx
+++ b/examples/basic-forms/1-basic-form-naive/src/example.tsx
@@ -1,0 +1,71 @@
+import {
+  createFormSchema,
+  useFormController,
+  useFormHandle,
+  useField,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const Schema = createFormSchema(fields => ({
+  name: fields.string(),
+  age: fields.number(),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema });
+  const form = useFormHandle(Schema, controller);
+  const name = useField(Schema.name, controller);
+  const age = useField(Schema.age, controller);
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        form.submit(values => alert(JSON.stringify(values, null, 2)));
+      }}
+      onReset={form.reset}
+    >
+      <section>
+        <label htmlFor={name.id}>Name:</label>
+        <input
+          id={name.id}
+          value={name.value}
+          onChange={e => name.setValue(e.target.value)}
+          onBlur={name.handleBlur}
+          autoComplete="off"
+        />
+      </section>
+
+      <section>
+        <label htmlFor={age.id}>Age:</label>
+        <input
+          type="number"
+          id={age.id}
+          value={age.value}
+          onChange={e =>
+            age.setValue(e.target.value === "" ? "" : +e.target.value)
+          }
+          onBlur={age.handleBlur}
+          autoComplete="off"
+        />
+      </section>
+
+      <section>
+        <button type="submit">Submit!</button>
+        <button type="reset">Reset</button>
+      </section>
+
+      <section>
+        <pre>
+          <h3>Debug</h3>
+          {JSON.stringify({ form, fields: { name, age } }, null, 2)}
+        </pre>
+      </section>
+    </form>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/basic-forms/2-basic-form-improved/README.md
+++ b/examples/basic-forms/2-basic-form-improved/README.md
@@ -1,0 +1,12 @@
+# Basic Form Improved Example
+
+This example showcases recommended approach to creating forms with `Formts`
+
+### Notes:
+
+Each component subscribes to relevant piece of form state and does not re-render
+when other pieces change.
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/2-basic-form-improved)

--- a/examples/basic-forms/2-basic-form-improved/index.css
+++ b/examples/basic-forms/2-basic-form-improved/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/basic-forms/2-basic-form-improved/package.json
+++ b/examples/basic-forms/2-basic-form-improved/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/basic-form-improved",
+  "description": "This example showcases recommended approach to creating forms with Formts",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/basic-forms/2-basic-form-improved/src/example.tsx
+++ b/examples/basic-forms/2-basic-form-improved/src/example.tsx
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import {
+  createFormSchema,
+  useFormController,
+  useFormHandle,
+  useField,
+  useFormValues,
+  FormProvider,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const Schema = createFormSchema(fields => ({
+  name: fields.string(),
+  age: fields.number(),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema });
+
+  return (
+    <FormProvider controller={controller}>
+      <form onSubmit={e => e.preventDefault()}>
+        <NameField />
+        <AgeField />
+        <FormActions />
+        <Debug />
+      </form>
+    </FormProvider>
+  );
+};
+
+const NameField: React.FC = () => {
+  const field = useField(Schema.name);
+
+  return (
+    <section>
+      <label htmlFor={field.id}>Name:</label>
+      <input
+        id={field.id}
+        value={field.value}
+        onChange={e => field.setValue(e.target.value)}
+        onBlur={field.handleBlur}
+        autoComplete="off"
+      />
+    </section>
+  );
+};
+
+const AgeField: React.FC = () => {
+  const field = useField(Schema.age);
+
+  return (
+    <section>
+      <label htmlFor={field.id}>Age:</label>
+      <input
+        type="number"
+        id={field.id}
+        value={field.value}
+        onChange={e =>
+          field.setValue(e.target.value === "" ? "" : +e.target.value)
+        }
+        onBlur={field.handleBlur}
+        autoComplete="off"
+      />
+    </section>
+  );
+};
+
+const FormActions: React.FC = () => {
+  const form = useFormHandle(Schema);
+
+  return (
+    <section>
+      <button
+        type="submit"
+        onClick={() =>
+          form.submit(values => alert(JSON.stringify(values, null, 2)))
+        }
+      >
+        Submit!
+      </button>
+
+      <button type="reset" onClick={form.reset}>
+        Reset
+      </button>
+    </section>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const name = useField(Schema.name);
+  const age = useField(Schema.age);
+
+  const info = {
+    values,
+    form,
+    fields: { name, age },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/basic-forms/3-basic-form-validation/README.md
+++ b/examples/basic-forms/3-basic-form-validation/README.md
@@ -1,0 +1,15 @@
+# Basic Form Validation Example
+
+This example showcases very simple validation using `Formts` validation API
+
+### Notes:
+
+- To run validation on mount just invoke `form.validate()` inside
+  `React.useEffect` hook.
+- Consider decoupling errors from presentation layer - see `TODO` example
+- Check out more advanced validation API features in `/advanced-forms` directory
+  // TODO
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/3-basic-form-validation)

--- a/examples/basic-forms/3-basic-form-validation/index.css
+++ b/examples/basic-forms/3-basic-form-validation/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/basic-forms/3-basic-form-validation/package.json
+++ b/examples/basic-forms/3-basic-form-validation/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/basic-form-validation",
+  "description": "This example showcases very simple validation using Formts validation API",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/basic-forms/3-basic-form-validation/src/example.tsx
+++ b/examples/basic-forms/3-basic-form-validation/src/example.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import {
+  createFormSchema,
+  createFormValidator,
+  useFormController,
+  useFormHandle,
+  useField,
+  useFormValues,
+  FormProvider,
+  validators,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const Schema = createFormSchema(
+  fields => ({
+    name: fields.string(),
+    age: fields.number(),
+  }),
+  errors => errors<string>()
+);
+
+const validator = createFormValidator(Schema, validate => [
+  validate({
+    field: Schema.name,
+    rules: () => [
+      // you can mix built-in validators with custom functions
+      validators.withError(validators.required(), "Required"),
+      val => (val.length > 10 ? "Name must be max 10 characters long" : null),
+    ],
+  }),
+  validate({
+    field: Schema.age,
+    rules: () => [
+      validators.withError(validators.required(), "Required"),
+      validators.withError(validators.minValue(18), "Age must be at least 18"),
+    ],
+  }),
+]);
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema, validator });
+
+  return (
+    <FormProvider controller={controller}>
+      <form onSubmit={e => e.preventDefault()}>
+        <NameField />
+        <AgeField />
+        <FormActions />
+        <Debug />
+      </form>
+    </FormProvider>
+  );
+};
+
+const NameField: React.FC = () => {
+  const field = useField(Schema.name);
+
+  return (
+    <section>
+      <label htmlFor={field.id}>Name:</label>
+      <input
+        id={field.id}
+        value={field.value}
+        onChange={e => field.setValue(e.target.value)}
+        onBlur={field.handleBlur}
+        autoComplete="off"
+      />
+      <div className="error">{field.error}</div>
+    </section>
+  );
+};
+
+const AgeField: React.FC = () => {
+  const field = useField(Schema.age);
+
+  return (
+    <section>
+      <label htmlFor={field.id}>Age:</label>
+      <input
+        type="number"
+        id={field.id}
+        value={field.value}
+        onChange={e =>
+          field.setValue(e.target.value === "" ? "" : +e.target.value)
+        }
+        onBlur={field.handleBlur}
+        autoComplete="off"
+      />
+      <div className="error">{field.error}</div>
+    </section>
+  );
+};
+
+const FormActions: React.FC = () => {
+  const form = useFormHandle(Schema);
+
+  return (
+    <section>
+      <button
+        type="submit"
+        disabled={form.isValid === false}
+        onClick={() =>
+          form.submit(values => alert(JSON.stringify(values, null, 2)))
+        }
+      >
+        Submit!
+      </button>
+
+      <button type="reset" onClick={form.reset}>
+        Reset
+      </button>
+    </section>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const name = useField(Schema.name);
+  const age = useField(Schema.age);
+
+  const info = {
+    values,
+    form,
+    fields: { name, age },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/basic-forms/4-basic-form-mui/README.md
+++ b/examples/basic-forms/4-basic-form-mui/README.md
@@ -1,0 +1,12 @@
+# Basic Form Material-UI Example
+
+This example showcases integration with third-party component library.
+
+### Notes:
+
+Since `Formts` is presentation-layer-agnostic and relies on controlled inputs it
+is just as easy to use custom components as native HTML inputs.
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/4-basic-form-mui)

--- a/examples/basic-forms/4-basic-form-mui/index.css
+++ b/examples/basic-forms/4-basic-form-mui/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/basic-forms/4-basic-form-mui/package.json
+++ b/examples/basic-forms/4-basic-form-mui/package.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/basic-form-mui",
+  "description": "This example showcases integration with third-party component library",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "@material-ui/core": "4.11.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/basic-forms/4-basic-form-mui/src/example.tsx
+++ b/examples/basic-forms/4-basic-form-mui/src/example.tsx
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import { Button, TextField, Box } from "@material-ui/core";
+import {
+  createFormSchema,
+  createFormValidator,
+  useFormController,
+  useFormHandle,
+  useField,
+  useFormValues,
+  FormProvider,
+  validators,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const Schema = createFormSchema(
+  fields => ({
+    name: fields.string(),
+    age: fields.number(),
+  }),
+  errors => errors<string>()
+);
+
+const validator = createFormValidator(Schema, validate => [
+  validate({
+    field: Schema.name,
+    rules: () => [
+      // you can mix built-in validators with custom functions
+      validators.withError(validators.required(), "Required"),
+      val => (val.length > 10 ? "Name must be max 10 characters long" : null),
+    ],
+  }),
+  validate({
+    field: Schema.age,
+    rules: () => [
+      validators.withError(validators.required(), "Required"),
+      validators.withError(validators.minValue(18), "Age must be at least 18"),
+    ],
+  }),
+]);
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema, validator });
+
+  return (
+    <FormProvider controller={controller}>
+      <form onSubmit={e => e.preventDefault()}>
+        <NameField />
+        <AgeField />
+        <FormActions />
+        <Debug />
+      </form>
+    </FormProvider>
+  );
+};
+
+const NameField: React.FC = () => {
+  const field = useField(Schema.name);
+
+  return (
+    <Box component="section" margin={2}>
+      <TextField
+        type="text"
+        label="Name:"
+        id={field.id}
+        value={field.value}
+        onChange={e => field.setValue(e.target.value)}
+        onBlur={field.handleBlur}
+        error={field.error != null}
+        helperText={field.error}
+        autoComplete="off"
+      />
+    </Box>
+  );
+};
+
+const AgeField: React.FC = () => {
+  const field = useField(Schema.age);
+
+  return (
+    <Box component="section" margin={2}>
+      <TextField
+        type="number"
+        label="Age:"
+        id={field.id}
+        value={field.value}
+        onChange={e =>
+          field.setValue(e.target.value === "" ? "" : +e.target.value)
+        }
+        onBlur={field.handleBlur}
+        error={field.error != null}
+        helperText={field.error}
+        autoComplete="off"
+      />
+    </Box>
+  );
+};
+
+const FormActions: React.FC = () => {
+  const form = useFormHandle(Schema);
+
+  return (
+    <Box component="section" margin={3}>
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        disabled={form.isValid === false}
+        onClick={() =>
+          form.submit(values => alert(JSON.stringify(values, null, 2)))
+        }
+      >
+        Submit
+      </Button>
+
+      <Button
+        variant="outlined"
+        color="secondary"
+        type="reset"
+        onClick={form.reset}
+      >
+        Reset
+      </Button>
+    </Box>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const name = useField(Schema.name);
+  const age = useField(Schema.age);
+
+  const info = {
+    values,
+    form,
+    fields: { name, age },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));


### PR DESCRIPTION
create `/examples` folder with some examples that can be opened in CodeSandbox. More examples to come in next PRs

check out the sandboxes:
- [basic-form-naive](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/1-basic-form-naive)
- [basic-form-improved](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/2-basic-form-improved)
- [basic-form-validation](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/3-basic-form-validation)
- [basic-form-mui](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples/examples/basic-forms/4-basic-form-mui)