### PR TITLE
feat(core): validators api v2

### DIFF
--- a/src/core/builders/create-form-schema.ts
+++ b/src/core/builders/create-form-schema.ts
@@ -81,11 +81,20 @@ const createFieldDescriptor = (
       return rootDescriptor;
 
     case "array": {
-      const nth = (i: number) =>
+      const nthHandler = (i: number) =>
         createFieldDescriptor(
           decoder.inner as _FieldDecoderImpl<any>,
           `${path}[${i}]`
         );
+
+      const nth = defineProperties(nthHandler, {
+        __rootPath: {
+          value: path,
+          enumerable: false,
+          writable: false,
+          configurable: false,
+        },
+      });
 
       return Object.assign(rootDescriptor, { nth });
     }

--- a/src/core/builders/create-form-validator.spec.ts
+++ b/src/core/builders/create-form-validator.spec.ts
@@ -168,7 +168,7 @@ describe("createFormValidator", () => {
     const { validate } = createFormValidator(Schema, validate => [
       validate({
         field: Schema.choice,
-        rules: () => [x => (x === "A" ? "INVALID_CHOICE" : null)],
+        rules: () => [x => (x === "A" ? "INVALID_VALUE" : null)],
       }),
     ]);
     const getValue = () => "C" as any;
@@ -669,7 +669,7 @@ describe("createFormValidator", () => {
     const { validate } = createFormValidator(Schema, validate => [
       validate({
         field: Schema.arrayObjectString,
-        rules: () => [x => (x.length < 3 ? "TOO_SHORT" : undefined)],
+        rules: () => [x => (x.length < 3 ? "TOO_SHORT" : null)],
       }),
       validate({
         field: Schema.arrayObjectString.nth,

--- a/src/core/builders/create-form-validator.spec.ts
+++ b/src/core/builders/create-form-validator.spec.ts
@@ -280,8 +280,8 @@ describe("createFormValidator", () => {
 
   it("validate.each should run for each element of list", async () => {
     const { validate } = createFormValidator(Schema, validate => [
-      validate.each({
-        field: Schema.arrayObjectString,
+      validate({
+        field: Schema.arrayObjectString.nth,
         rules: () => [
           x => wait(x.str === "invalid" ? "INVALID_VALUE" : null),
           x => (x.str === "" ? "REQUIRED" : null),
@@ -289,6 +289,7 @@ describe("createFormValidator", () => {
         ],
       }),
     ]);
+
     const getValue = (field: FieldDescriptor<any>): any => {
       switch (impl(field).__path) {
         case "arrayObjectString[0]":
@@ -322,12 +323,12 @@ describe("createFormValidator", () => {
 
   it("validate.each for multiple arrays should run for each element of corresponding list", async () => {
     const { validate } = createFormValidator(Schema, validate => [
-      validate.each({
-        field: Schema.arrayObjectString,
+      validate({
+        field: Schema.arrayObjectString.nth,
         rules: () => [x => wait(x.str?.length < 3 ? "TOO_SHORT" : null)],
       }),
-      validate.each({
-        field: Schema.arrayChoice,
+      validate({
+        field: Schema.arrayChoice.nth,
         rules: () => [x => wait(x === "c" ? "INVALID_VALUE" : null)],
       }),
     ]);
@@ -485,8 +486,8 @@ describe("createFormValidator", () => {
         field: Schema.string,
         rules: () => [x => (x.length < 3 ? "TOO_SHORT" : null)],
       }),
-      validate.each({
-        field: Schema.arrayString,
+      validate({
+        field: Schema.arrayString.nth,
         rules: () => [x => wait(x.length < 3 ? "TOO_SHORT" : null)],
       }),
       validate({
@@ -537,8 +538,8 @@ describe("createFormValidator", () => {
         field: Schema.string,
         rules: () => [pass],
       }),
-      validate.each({
-        field: Schema.arrayString,
+      validate({
+        field: Schema.arrayString.nth,
         rules: () => [pass],
       }),
       validate({
@@ -670,8 +671,8 @@ describe("createFormValidator", () => {
         field: Schema.arrayObjectString,
         rules: () => [x => (x.length < 3 ? "TOO_SHORT" : undefined)],
       }),
-      validate.each({
-        field: Schema.arrayObjectString,
+      validate({
+        field: Schema.arrayObjectString.nth,
         rules: () => [x => (x.str === "" ? "REQUIRED" : null)],
       }),
     ]);
@@ -742,8 +743,8 @@ describe("createFormValidator", () => {
         field: Schema.objectObjectArrayObjectString.obj.array,
         rules: () => [arrayValidator],
       }),
-      validate.each({
-        field: Schema.objectObjectArrayObjectString.obj.array,
+      validate({
+        field: Schema.objectObjectArrayObjectString.obj.array.nth,
         rules: () => [arrayItemValidator],
       }),
       validate({

--- a/src/core/builders/create-form-validator.ts
+++ b/src/core/builders/create-form-validator.ts
@@ -124,7 +124,7 @@ const validate: ValidateFn = <T, Err, Deps extends any[]>(
   ...rules: Array<Validator<T, Err>>
 ): FieldValidator<T, Err, Deps> => {
   const config: ValidateConfig<T, Err, Deps> =
-    typeof x === "object"
+    (x as any)["field"] != null
       ? { ...(x as ValidateConfig<T, Err, Deps>) }
       : { field: x as ValidateField<T, Err>, rules: () => rules };
 

--- a/src/core/builders/create-form-validator.ts
+++ b/src/core/builders/create-form-validator.ts
@@ -129,16 +129,9 @@ const validate: ValidateFn = <T, Err, Deps extends any[]>(
       : { field: x as ValidateField<T, Err>, rules: () => rules };
 
   const isNth = typeof config.field === "function";
-  let path = "";
-
-  if (isNth) {
-    const firstElementPath = impl(
-      (config.field as ArrayFieldDescriptor<T[], Err>["nth"])(0)
-    ).__path;
-    path = firstElementPath.slice(0, -3);
-  } else {
-    path = impl(config.field as FieldDescriptor<T, Err>).__path;
-  }
+  let path = isNth
+    ? impl(config.field as ArrayFieldDescriptor<T[], Err>["nth"]).__rootPath
+    : impl(config.field as FieldDescriptor<T, Err>).__path;
 
   return {
     type: isNth ? "each" : "field",

--- a/src/core/builders/create-form-validator.ts
+++ b/src/core/builders/create-form-validator.ts
@@ -62,7 +62,7 @@ export const createFormValidator = <Values extends object, Err>(
     const rootArrayPath = getRootArrayPath(path);
 
     return allValidators.filter(x => {
-      const xPath = impl(x.field).__path;
+      const xPath = x.path;
       const isFieldMatch = x.type === "field" && xPath === path;
       const isEachMatch = x.type === "each" && xPath === rootArrayPath;
       const triggerMatches =
@@ -142,7 +142,7 @@ const validate: ValidateFn = <T, Err, Deps extends any[]>(
 
   return {
     type: isNth ? "each" : "field",
-    field: { __path: path } as any,
+    path,
     triggers: config.triggers,
     validators: config.rules,
     dependencies: config.dependencies,

--- a/src/core/builders/create-form-validator.ts
+++ b/src/core/builders/create-form-validator.ts
@@ -62,9 +62,8 @@ export const createFormValidator = <Values extends object, Err>(
     const rootArrayPath = getRootArrayPath(path);
 
     return allValidators.filter(x => {
-      const xPath = x.path;
-      const isFieldMatch = x.type === "field" && xPath === path;
-      const isEachMatch = x.type === "each" && xPath === rootArrayPath;
+      const isFieldMatch = x.type === "field" && x.path === path;
+      const isEachMatch = x.type === "each" && x.path === rootArrayPath;
       const triggerMatches =
         trigger && x.triggers ? x.triggers.includes(trigger) : true;
 
@@ -129,7 +128,7 @@ const validate: ValidateFn = <T, Err, Deps extends any[]>(
       : { field: x as ValidateField<T, Err>, rules: () => rules };
 
   const isNth = typeof config.field === "function";
-  let path = isNth
+  const path = isNth
     ? impl(config.field as ArrayFieldDescriptor<T[], Err>["nth"]).__rootPath
     : impl(config.field as FieldDescriptor<T, Err>).__path;
 

--- a/src/core/builders/create-form-validator.ts
+++ b/src/core/builders/create-form-validator.ts
@@ -63,7 +63,6 @@ export const createFormValidator = <Values extends object, Err>(
 
     return allValidators.filter(x => {
       const xPath = impl(x.field).__path;
-      // console.log("VALIDATOR PATH vs PATH", xPath, rootArrayPath)
       const isFieldMatch = x.type === "field" && xPath === path;
       const isEachMatch = x.type === "each" && xPath === rootArrayPath;
       const triggerMatches =

--- a/src/core/types/field-descriptor.ts
+++ b/src/core/types/field-descriptor.ts
@@ -9,6 +9,11 @@ export type _FieldDescriptorImpl<T> = {
   __decoder: _FieldDecoderImpl<T>;
 };
 
+export type _NTHHandler<T> = {
+  __rootPath: string;
+  (n: number): _FieldDecoderImpl<T>;
+};
+
 /**
  * Pointer to a form field.
  * Used to interact with Formts API via `useField` hook.

--- a/src/core/types/form-validator.spec.ts
+++ b/src/core/types/form-validator.spec.ts
@@ -59,6 +59,23 @@ describe("validateFn", () => {
     assert<IsExact<Actual, Expected>>(true);
   });
 
+  it("resolves properly for array nth", () => {
+    const arrayFieldValidator = validator({
+      field: fd4.nth,
+      dependencies: [fd1, fd2, fd3, fd5],
+      rules: (_string, _number, _choice, _obj) => [false],
+    });
+
+    type Actual = typeof arrayFieldValidator;
+    type Expected = FieldValidator<
+      Date,
+      Err,
+      [string, number, "a" | "b" | "c", { parent: { child: string[] } }]
+    >;
+
+    assert<IsExact<Actual, Expected>>(true);
+  });
+
   it("resolves properly for object array", () => {
     const objFieldValidator = validator({
       field: fd5,
@@ -84,6 +101,33 @@ describe("validateFn", () => {
 
     type Actual = typeof fieldValidator;
     type Expected = FieldValidator<string, Err, []>;
+
+    assert<IsExact<Actual, Expected>>(true);
+  });
+
+  it("resolves properly for simple signature", () => {
+    const stringFieldValidator = validator(fd1, () => null);
+
+    type Actual = typeof stringFieldValidator;
+    type Expected = FieldValidator<string, Err, []>;
+
+    assert<IsExact<Actual, Expected>>(true);
+  });
+
+  it("resolves properly for simple signature for array", () => {
+    const stringFieldValidator = validator(fd4, () => null);
+
+    type Actual = typeof stringFieldValidator;
+    type Expected = FieldValidator<Date[], Err, []>;
+
+    assert<IsExact<Actual, Expected>>(true);
+  });
+
+  it("resolves properly for simple signature for array.nth", () => {
+    const stringFieldValidator = validator(fd4.nth, () => null);
+
+    type Actual = typeof stringFieldValidator;
+    type Expected = FieldValidator<Date, Err, []>;
 
     assert<IsExact<Actual, Expected>>(true);
   });

--- a/src/core/types/form-validator.spec.ts
+++ b/src/core/types/form-validator.spec.ts
@@ -79,7 +79,7 @@ describe("validateFn", () => {
   it("resolves properly with no dependencies", () => {
     const fieldValidator = validator({
       field: fd1,
-      rules: () => [false],
+      rules: () => [null],
     });
 
     type Actual = typeof fieldValidator;

--- a/src/core/types/form-validator.ts
+++ b/src/core/types/form-validator.ts
@@ -52,22 +52,26 @@ export type FieldValidator<T, Err, Dependencies extends any[]> = {
 };
 
 export type ValidateFn = {
-  each: ValidateEachFn;
+  <T, Err>(
+    field: ValidateField<T, Err>,
+    ...rules: Array<Validator<T, Err>>
+  ): FieldValidator<T, Err, []>;
 
-  <T, Err, Dependencies extends any[]>(config: {
-    field: GenericFieldDescriptor<T, Err>;
-    triggers?: ValidationTrigger[];
-    dependencies?: readonly [...FieldDescTuple<Dependencies>];
-    rules: (...deps: [...Dependencies]) => Array<Falsy | Validator<T, Err>>;
-  }): FieldValidator<T, Err, Dependencies>;
+  <T, Err, Dependencies extends any[]>(
+    config: ValidateConfig<T, Err, Dependencies>
+  ): FieldValidator<T, Err, Dependencies>;
 };
 
-export type ValidateEachFn = <T, Err, Dependencies extends any[]>(config: {
-  field: ArrayFieldDescriptor<T[], Err>;
+export type ValidateConfig<T, Err, Dependencies extends any[]> = {
+  field: ValidateField<T, Err>;
   triggers?: ValidationTrigger[];
   dependencies?: readonly [...FieldDescTuple<Dependencies>];
   rules: (...deps: [...Dependencies]) => Array<Falsy | Validator<T, Err>>;
-}) => FieldValidator<T, Err, Dependencies>;
+};
+
+export type ValidateField<T, Err> =
+  | GenericFieldDescriptor<T, Err>
+  | ArrayFieldDescriptor<T[], Err>["nth"];
 
 type FieldDescTuple<ValuesTuple extends readonly any[]> = {
   [Index in keyof ValuesTuple]: GenericFieldDescriptor<ValuesTuple[Index]>;

--- a/src/core/types/form-validator.ts
+++ b/src/core/types/form-validator.ts
@@ -45,7 +45,7 @@ export type FormValidator<Values extends object, Err> = {
 
 export type FieldValidator<T, Err, Dependencies extends any[]> = {
   type: "field" | "each";
-  field: FieldDescriptor<T, Err>;
+  path: string;
   triggers?: Array<ValidationTrigger>;
   validators: (...deps: [...Dependencies]) => Array<Falsy | Validator<T, Err>>;
   dependencies?: readonly [...FieldDescTuple<Dependencies>];

--- a/src/core/types/form-validator.ts
+++ b/src/core/types/form-validator.ts
@@ -52,14 +52,14 @@ export type FieldValidator<T, Err, Dependencies extends any[]> = {
 };
 
 export type ValidateFn = {
+  <T, Err, Dependencies extends any[]>(
+    config: ValidateConfig<T, Err, Dependencies>
+  ): FieldValidator<T, Err, Dependencies>;
+
   <T, Err>(
     field: ValidateField<T, Err>,
     ...rules: Array<Validator<T, Err>>
   ): FieldValidator<T, Err, []>;
-
-  <T, Err, Dependencies extends any[]>(
-    config: ValidateConfig<T, Err, Dependencies>
-  ): FieldValidator<T, Err, Dependencies>;
 };
 
 export type ValidateConfig<T, Err, Dependencies extends any[]> = {

--- a/src/core/types/form-validator.ts
+++ b/src/core/types/form-validator.ts
@@ -1,4 +1,4 @@
-import { Falsy } from "../../utils";
+import { Falsy, NoInfer } from "../../utils";
 
 import {
   ArrayFieldDescriptor,
@@ -58,7 +58,7 @@ export type ValidateFn = {
 
   <T, Err>(
     field: ValidateField<T, Err>,
-    ...rules: Array<Validator<T, Err>>
+    ...rules: Array<Validator<T, NoInfer<Err>>>
   ): FieldValidator<T, Err, []>;
 };
 
@@ -66,7 +66,9 @@ export type ValidateConfig<T, Err, Dependencies extends any[]> = {
   field: ValidateField<T, Err>;
   triggers?: ValidationTrigger[];
   dependencies?: readonly [...FieldDescTuple<Dependencies>];
-  rules: (...deps: [...Dependencies]) => Array<Falsy | Validator<T, Err>>;
+  rules: (
+    ...deps: [...Dependencies]
+  ) => Array<Falsy | Validator<T, NoInfer<Err>>>;
 };
 
 export type ValidateField<T, Err> =

--- a/src/core/types/type-mapper-util.ts
+++ b/src/core/types/type-mapper-util.ts
@@ -4,6 +4,7 @@ import {
   ArrayFieldDescriptor,
   ObjectFieldDescriptor,
   _FieldDescriptorImpl,
+  _NTHHandler,
 } from "./field-descriptor";
 import { FormController, _FormControllerImpl } from "./form-controller";
 
@@ -26,6 +27,10 @@ type GetImplFn = {
   <T>(it: FieldDecoder<T>): _FieldDecoderImpl<T>;
 
   <V extends object, Err>(it: FormController): _FormControllerImpl<V, Err>;
+
+  <T extends any>(it: ArrayFieldDescriptor<T[], unknown>["nth"]): _NTHHandler<
+    T
+  >;
 };
 
 /**

--- a/src/utils/utility-types.ts
+++ b/src/utils/utility-types.ts
@@ -45,3 +45,5 @@ export type WidenType<T> = [T] extends [string]
   : [T] extends [boolean]
   ? boolean
   : T;
+
+export type NoInfer<A> = [A][A extends any ? 0 : never];


### PR DESCRIPTION
* removed `validate.each` by adding a suport for passing `.nth` as validation target, which will trigger `validate.each` behavior
* extended `validate` signature with simpler alternative `validate(fieldDescriptor, rule1, rule2, ...)`