### PR TITLE
docs: codesandbox input examples

### DIFF
--- a/examples/basic-forms/1-basic-form-naive/README.md
+++ b/examples/basic-forms/1-basic-form-naive/README.md
@@ -1,4 +1,4 @@
-# Basic Form Naive Example
+# Basic form naive example
 
 This is the simplest possible example of `Formts` usage
 

--- a/examples/basic-forms/1-basic-form-naive/tsconfig.json
+++ b/examples/basic-forms/1-basic-form-naive/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/basic-forms/2-basic-form-improved/README.md
+++ b/examples/basic-forms/2-basic-form-improved/README.md
@@ -1,4 +1,4 @@
-# Basic Form Improved Example
+# Basic form improved example
 
 This example showcases recommended approach to creating forms with `Formts`
 

--- a/examples/basic-forms/2-basic-form-improved/tsconfig.json
+++ b/examples/basic-forms/2-basic-form-improved/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/basic-forms/3-basic-form-validation/README.md
+++ b/examples/basic-forms/3-basic-form-validation/README.md
@@ -1,4 +1,4 @@
-# Basic Form Validation Example
+# Basic form validation example
 
 This example showcases very simple validation using `Formts` validation API
 

--- a/examples/basic-forms/3-basic-form-validation/tsconfig.json
+++ b/examples/basic-forms/3-basic-form-validation/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/basic-forms/4-basic-form-mui/README.md
+++ b/examples/basic-forms/4-basic-form-mui/README.md
@@ -1,4 +1,4 @@
-# Basic Form Material-UI Example
+# Basic form Material-UI example
 
 This example showcases integration with third-party component library.
 

--- a/examples/basic-forms/4-basic-form-mui/tsconfig.json
+++ b/examples/basic-forms/4-basic-form-mui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/inputs/checkbox-group-input/README.md
+++ b/examples/inputs/checkbox-group-input/README.md
@@ -1,0 +1,13 @@
+# Checkbox group input example
+
+This example showcases usage of checkbox group input
+
+### Notes:
+
+Using object with boolean values is not necessary to get checkbox group working
+but seems most convenient. You can map this into other data-type after form is
+submitted.
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/input/checkbox-group-input)

--- a/examples/inputs/checkbox-group-input/README.md
+++ b/examples/inputs/checkbox-group-input/README.md
@@ -10,4 +10,4 @@ submitted.
 
 ---
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/input/checkbox-group-input)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/inputs/checkbox-group-input)

--- a/examples/inputs/checkbox-group-input/index.css
+++ b/examples/inputs/checkbox-group-input/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/inputs/checkbox-group-input/package.json
+++ b/examples/inputs/checkbox-group-input/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/checkbox-group-input",
+  "description": "This example showcases usage of checkbox group input",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/inputs/checkbox-group-input/src/example.tsx
+++ b/examples/inputs/checkbox-group-input/src/example.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import {
+  createFormSchema,
+  useFormController,
+  useField,
+  FormProvider,
+  useFormHandle,
+  useFormValues,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const entries = <T extends object>(o: T): [keyof T, T[keyof T]][] =>
+  Object.entries(o) as any;
+
+const Schema = createFormSchema(fields => ({
+  colors: fields.object({
+    red: fields.bool(),
+    green: fields.bool(),
+    blue: fields.bool(),
+  }),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema });
+
+  return (
+    <FormProvider controller={controller}>
+      <ColorsCheckboxGroup />
+      <Debug />
+    </FormProvider>
+  );
+};
+
+const ColorsCheckboxGroup: React.FC = () => {
+  const colors = useField(Schema.colors);
+
+  const labels = {
+    red: "Red",
+    green: "Green",
+    blue: "Blue",
+  };
+
+  return (
+    <fieldset>
+      <legend>Choose your favourite colors:</legend>
+
+      {/* 
+        we need custom-typed Object.entries in order for type of `key`
+        to be inferred properly to "red" | "green" | "blue" in this example 
+      */}
+      {entries(colors.children).map(([key, field]) => (
+        <div key={field.id}>
+          <input
+            id={field.id}
+            type="checkbox"
+            name={colors.id}
+            checked={field.value}
+            onBlur={field.handleBlur}
+            onChange={e => field.setValue(e.target.checked)}
+          />
+          <label htmlFor={field.id}>{labels[key]}</label>
+        </div>
+      ))}
+    </fieldset>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const colors = useField(Schema.colors);
+
+  const info = {
+    values,
+    form,
+    fields: { colors },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/inputs/checkbox-group-input/tsconfig.json
+++ b/examples/inputs/checkbox-group-input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/inputs/field-array-input/README.md
+++ b/examples/inputs/field-array-input/README.md
@@ -1,0 +1,7 @@
+# Field array input example
+
+This example showcases usage of field arrays
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/inputs/field-array-input)

--- a/examples/inputs/field-array-input/index.css
+++ b/examples/inputs/field-array-input/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/inputs/field-array-input/package.json
+++ b/examples/inputs/field-array-input/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/field-array-input",
+  "description": "This example showcases usage of field arrays",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/inputs/field-array-input/src/example.tsx
+++ b/examples/inputs/field-array-input/src/example.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import {
+  createFormSchema,
+  useFormController,
+  useField,
+  FormProvider,
+  useFormHandle,
+  useFormValues,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const Schema = createFormSchema(fields => ({
+  promoCodes: fields.array(fields.string()),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({
+    Schema,
+    initialValues: { promoCodes: [""] },
+  });
+
+  return (
+    <FormProvider controller={controller}>
+      <PromoCodesArrayInput />
+      <Debug />
+    </FormProvider>
+  );
+};
+
+const PromoCodesArrayInput: React.FC = () => {
+  const arrayField = useField(Schema.promoCodes);
+
+  return (
+    <fieldset>
+      <legend>Enter your promo codes!</legend>
+
+      {arrayField.children.map((field, i) => (
+        <section>
+          <input
+            key={field.id}
+            value={field.value}
+            onChange={e => field.setValue(e.target.value)}
+            onBlur={field.handleBlur}
+            autoComplete="off"
+          />
+          <button
+            onClick={() => arrayField.removeItem(i)}
+            disabled={arrayField.value.length === 1}
+          >
+            Remove
+          </button>
+        </section>
+      ))}
+
+      <button onClick={() => arrayField.addItem("")}>Add</button>
+    </fieldset>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const promoCodes = useField(Schema.promoCodes);
+
+  const info = {
+    values,
+    form,
+    fields: { promoCodes },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/inputs/field-array-input/tsconfig.json
+++ b/examples/inputs/field-array-input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/inputs/mui-date-picker-input/README.md
+++ b/examples/inputs/mui-date-picker-input/README.md
@@ -1,0 +1,7 @@
+# MaterialUI date-picker input example
+
+This example showcases usage of date picker input from MaterialUI
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/inputs/mui-date-picker-input)

--- a/examples/inputs/mui-date-picker-input/index.css
+++ b/examples/inputs/mui-date-picker-input/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/inputs/mui-date-picker-input/package.json
+++ b/examples/inputs/mui-date-picker-input/package.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/mui-date-picker-input",
+  "description": "This example showcases usage of date picker input from MaterialUI",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "@material-ui/core": "4.11.1",
+    "@material-ui/pickers": "3.2.10",
+    "@date-io/date-fns": "1.3.13",
+    "date-fns": "2.16.1",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/inputs/mui-date-picker-input/src/example.tsx
+++ b/examples/inputs/mui-date-picker-input/src/example.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import DateUtils from "@date-io/date-fns";
+import { Box } from "@material-ui/core";
+import { DatePicker, MuiPickersUtilsProvider } from "@material-ui/pickers";
+import {
+  createFormSchema,
+  useFormController,
+  useFormHandle,
+  useField,
+  useFormValues,
+  FormProvider,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const Schema = createFormSchema(fields => ({
+  date: fields.instanceOf(Date),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({
+    Schema,
+  });
+
+  return (
+    <MuiPickersUtilsProvider utils={DateUtils}>
+      <FormProvider controller={controller}>
+        <DatePickerInput />
+        <Debug />
+      </FormProvider>
+    </MuiPickersUtilsProvider>
+  );
+};
+
+const DatePickerInput: React.FC = () => {
+  const dateField = useField(Schema.date);
+
+  return (
+    <Box width={300}>
+      <DatePicker
+        variant="inline"
+        label="Choose your favourite date"
+        value={dateField.value}
+        onChange={date => dateField.setValue(date as Date)}
+        fullWidth
+        autoOk
+      />
+    </Box>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const date = useField(Schema.date);
+
+  const info = {
+    values,
+    form,
+    fields: { date },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/inputs/mui-date-picker-input/tsconfig.json
+++ b/examples/inputs/mui-date-picker-input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/inputs/mui-multi-select-input/README.md
+++ b/examples/inputs/mui-multi-select-input/README.md
@@ -1,0 +1,7 @@
+# MUI multi-select input example
+
+This example showcases usage of multiple select input from MaterialUI
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/inputs/mui-multi-select-input)

--- a/examples/inputs/mui-multi-select-input/README.md
+++ b/examples/inputs/mui-multi-select-input/README.md
@@ -1,4 +1,4 @@
-# MUI multi-select input example
+# MaterialUI multi-select input example
 
 This example showcases usage of multiple select input from MaterialUI
 

--- a/examples/inputs/mui-multi-select-input/index.css
+++ b/examples/inputs/mui-multi-select-input/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/inputs/mui-multi-select-input/package.json
+++ b/examples/inputs/mui-multi-select-input/package.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/mui-multi-select-input",
+  "description": "This example showcases usage of multiple select input from MaterialUI",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "@material-ui/core": "4.11.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/inputs/mui-multi-select-input/src/example.tsx
+++ b/examples/inputs/mui-multi-select-input/src/example.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Input,
+  Select,
+  MenuItem,
+  Checkbox,
+  ListItemText,
+} from "@material-ui/core";
+import {
+  createFormSchema,
+  useFormController,
+  useFormHandle,
+  useField,
+  useFormValues,
+  FormProvider,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const COLOR_VALUES = ["red", "green", "blue"] as const;
+
+const COLOR_LABELS = {
+  red: "Red",
+  green: "Green",
+  blue: "Blue",
+};
+
+const Schema = createFormSchema(fields => ({
+  colors: fields.array(fields.choice(...COLOR_VALUES)),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema });
+
+  return (
+    <FormProvider controller={controller}>
+      <ColorsMultiSelectInput />
+      <Debug />
+    </FormProvider>
+  );
+};
+
+const ColorsMultiSelectInput: React.FC = () => {
+  const colors = useField(Schema.colors);
+
+  return (
+    <Box width={300}>
+      <FormControl fullWidth>
+        <InputLabel id={colors.id}>Choose your favourite colors:</InputLabel>
+        <Select
+          labelId={colors.id}
+          value={colors.value}
+          onChange={e => {
+            // TODO: simplify when field.handleChange is implemented
+            colors.setValue(e.target.value as Array<"red" | "green" | "blue">);
+          }}
+          input={<Input />}
+          renderValue={selected => (selected as string[]).join(", ")}
+          multiple
+        >
+          {COLOR_VALUES.map(color => (
+            <MenuItem key={color} value={color}>
+              <Checkbox checked={colors.value.includes(color)} />
+              <ListItemText primary={COLOR_LABELS[color]} />
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const colors = useField(Schema.colors);
+
+  const info = {
+    values,
+    form,
+    fields: { colors },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/inputs/mui-multi-select-input/tsconfig.json
+++ b/examples/inputs/mui-multi-select-input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/inputs/radio-group-input/README.md
+++ b/examples/inputs/radio-group-input/README.md
@@ -1,0 +1,7 @@
+# Checkbox group input example
+
+This example showcases usage of radio group input
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/inputs/radio-group-input)

--- a/examples/inputs/radio-group-input/index.css
+++ b/examples/inputs/radio-group-input/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/inputs/radio-group-input/package.json
+++ b/examples/inputs/radio-group-input/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/radio-group-input",
+  "description": "This example showcases usage of radio group input",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/inputs/radio-group-input/src/example.tsx
+++ b/examples/inputs/radio-group-input/src/example.tsx
@@ -14,7 +14,7 @@ import ReactDOM from "react-dom";
 import "../index.css";
 
 const Schema = createFormSchema(fields => ({
-  color: fields.choice("red", "green", "blue"),
+  colors: fields.choice("", "red", "green", "blue"),
 }));
 
 const Example: React.FC = () => {
@@ -22,42 +22,39 @@ const Example: React.FC = () => {
 
   return (
     <FormProvider controller={controller}>
-      <ColorSelectInput />
+      <ColorsRadioGroup />
       <Debug />
     </FormProvider>
   );
 };
 
-const ColorSelectInput: React.FC = () => {
-  const field = useField(Schema.color);
+const ColorsRadioGroup: React.FC = () => {
+  const colors = useField(Schema.colors);
 
   const labels = {
     red: "Red",
     green: "Green",
     blue: "Blue",
   };
-  type Color = keyof typeof field.options;
 
   return (
-    <>
-      <label htmlFor={field.id}>Choose your favourite color:</label>
-      <select
-        id={field.id}
-        value={field.value}
-        onChange={e => field.setValue(e.target.value as Color)}
-        onBlur={field.handleBlur}
-      >
-        {/* 
-         we need custom-typed Object.keys in order for type of `option`
-         to be inferred properly to "red" | "green" | "blue" in this example 
-        */}
-        {Object.values(field.options).map(option => (
-          <option key={option} value={option}>
-            {labels[option]}
-          </option>
-        ))}
-      </select>
-    </>
+    <fieldset>
+      <legend>Choose your favourite color:</legend>
+
+      {Object.values(colors.options).map(option => (
+        <div key={colors.id}>
+          <input
+            id={option}
+            type="radio"
+            name={colors.id}
+            checked={colors.value === option}
+            onBlur={colors.handleBlur}
+            onChange={e => e.target.checked && colors.setValue(option)}
+          />
+          <label htmlFor={option}>{labels[option]}</label>
+        </div>
+      ))}
+    </fieldset>
   );
 };
 
@@ -65,12 +62,12 @@ const Debug: React.FC = () => {
   const form = useFormHandle(Schema);
   const values = useFormValues(Schema);
 
-  const color = useField(Schema.color);
+  const colors = useField(Schema.colors);
 
   const info = {
     values,
     form,
-    fields: { color },
+    fields: { colors },
   };
 
   return (

--- a/examples/inputs/radio-group-input/tsconfig.json
+++ b/examples/inputs/radio-group-input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/examples/inputs/select-input/README.md
+++ b/examples/inputs/select-input/README.md
@@ -1,0 +1,7 @@
+# Checkbox group input example
+
+This example showcases usage of select input
+
+---
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/VirtusLab/formts/tree/master/examples/inputs/select-input)

--- a/examples/inputs/select-input/README.md
+++ b/examples/inputs/select-input/README.md
@@ -1,4 +1,4 @@
-# Checkbox group input example
+# Select input example
 
 This example showcases usage of select input
 

--- a/examples/inputs/select-input/index.css
+++ b/examples/inputs/select-input/index.css
@@ -1,0 +1,32 @@
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18px;
+}
+
+section {
+  margin: 10px 0;
+}
+
+button {
+  padding: 0 10px;
+  font-size: 18px;
+  margin: 0 10px;
+}
+
+label {
+  padding: 0 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+pre {
+  margin: 30px 0;
+  padding: 10px;
+  background-color: #eee;
+}
+
+.error {
+  font-size: 14px;
+  padding: 5px 10px;
+  color: red;
+}

--- a/examples/inputs/select-input/package.json
+++ b/examples/inputs/select-input/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "@formts-examples/select-input",
+  "description": "This example showcases usage of select input",
+  "main": "src/example.tsx",
+  "dependencies": {
+    "@virtuslab/formts": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-scripts": "4.0.0"
+  }
+}

--- a/examples/inputs/select-input/src/example.tsx
+++ b/examples/inputs/select-input/src/example.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+import {
+  createFormSchema,
+  useFormController,
+  useField,
+  FormProvider,
+  useFormHandle,
+  useFormValues,
+} from "@virtuslab/formts";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "../index.css";
+
+const keys = <T extends object>(o: T): Array<keyof T> => Object.keys(o) as any;
+
+const Schema = createFormSchema(fields => ({
+  color: fields.choice("red", "green", "blue"),
+}));
+
+const Example: React.FC = () => {
+  const controller = useFormController({ Schema });
+
+  return (
+    <FormProvider controller={controller}>
+      <ColorSelectInput />
+      <Debug />
+    </FormProvider>
+  );
+};
+
+const ColorSelectInput: React.FC = () => {
+  const field = useField(Schema.color);
+
+  const labels = {
+    red: "Red",
+    green: "Green",
+    blue: "Blue",
+  };
+  type Color = keyof typeof field.options;
+
+  return (
+    <>
+      <label htmlFor={field.id}>Choose your favourite color:</label>
+      <select
+        id={field.id}
+        value={field.value}
+        onChange={e => field.setValue(e.target.value as Color)}
+        onBlur={field.handleBlur}
+      >
+        {/* 
+         we need custom-typed Object.keys in order for type of `option`
+         to be inferred properly to "red" | "green" | "blue" in this example 
+        */}
+        {keys(field.options).map(option => (
+          <option key={option} value={option}>
+            {labels[option]}
+          </option>
+        ))}
+      </select>
+    </>
+  );
+};
+
+const Debug: React.FC = () => {
+  const form = useFormHandle(Schema);
+  const values = useFormValues(Schema);
+
+  const color = useField(Schema.color);
+
+  const info = {
+    values,
+    form,
+    fields: { color },
+  };
+
+  return (
+    <pre>
+      <h3>Debug</h3>
+      {JSON.stringify(info, null, 2)}
+    </pre>
+  );
+};
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/inputs/select-input/tsconfig.json
+++ b/examples/inputs/select-input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "ES2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/src/core/hooks/hooks.spec.tsx
+++ b/src/core/hooks/hooks.spec.tsx
@@ -13,7 +13,7 @@ import { useFormController, useFormValues } from ".";
 const Schema = createFormSchema(
   fields => ({
     theString: fields.string(),
-    theChoice: fields.choice("A", "B", "C"),
+    theChoice: fields.choice("", "A", "B", "C"),
     theNum: fields.number(),
     theBool: fields.bool(),
     theInstance: fields.instanceOf(Date),
@@ -64,7 +64,7 @@ describe("formts hooks API", () => {
 
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: "",
         theBool: false,
         theInstance: null,
@@ -148,7 +148,7 @@ describe("formts hooks API", () => {
 
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: "",
         theBool: false,
         theInstance: null,
@@ -207,7 +207,7 @@ describe("formts hooks API", () => {
     const values = formValuesHook.current;
     expect(values).toEqual({
       theString: "",
-      theChoice: "A",
+      theChoice: "",
       theNum: "",
       theBool: false,
       theInstance: null,
@@ -343,7 +343,7 @@ describe("formts hooks API", () => {
       expect(formHandleHook.current.isTouched).toBe(false);
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: "",
         theBool: false,
         theInstance: null,
@@ -371,7 +371,7 @@ describe("formts hooks API", () => {
       expect(formHandleHook.current.isTouched).toBe(true);
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: 42,
         theBool: false,
         theInstance: null,
@@ -402,7 +402,7 @@ describe("formts hooks API", () => {
       expect(formHandleHook.current.isTouched).toBe(true);
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: 42,
         theBool: false,
         theInstance: null,
@@ -430,7 +430,7 @@ describe("formts hooks API", () => {
       expect(formHandleHook.current.isTouched).toBe(true);
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: 42,
         theBool: false,
         theInstance: null,
@@ -676,7 +676,7 @@ describe("formts hooks API", () => {
       expect(formHandleHook.current.isTouched).toBe(true);
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: 666,
         theBool: false,
         theInstance: null,
@@ -696,7 +696,7 @@ describe("formts hooks API", () => {
       expect(formHandleHook.current.isTouched).toBe(false);
       expect(formValuesHook.current).toEqual({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: 42,
         theBool: false,
         theInstance: null,
@@ -1009,7 +1009,7 @@ describe("formts hooks API", () => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
       expect(onSuccess).toHaveBeenCalledWith({
         theString: "",
-        theChoice: "A",
+        theChoice: "",
         theNum: "",
         theBool: false,
         theInstance: null,

--- a/src/core/hooks/use-field/use-field.ts
+++ b/src/core/hooks/use-field/use-field.ts
@@ -100,7 +100,7 @@ const createFieldHandle = <T, Err>(
     get options() {
       const decoder = impl(descriptor).__decoder;
       return isChoiceDecoder(decoder)
-        ? toIdentityDict(decoder.options as string[])
+        ? toIdentityDict((decoder.options as string[]).filter(opt => opt != ""))
         : undefined;
     },
 

--- a/src/core/types/field-handle.ts
+++ b/src/core/types/field-handle.ts
@@ -111,7 +111,7 @@ type ObjectFieldHandle<T, Err> = T extends Array<any>
 type ChoiceFieldHandle<T> = [T] extends [string]
   ? IsUnion<T> extends true
     ? {
-        /** Dictionary containing options specified in Schema using `choice` function */
+        /** Dictionary containing options specified in Schema using `choice` function (excluding `""`) */
         options: IdentityDict<Exclude<T, "">>;
       }
     : void


### PR DESCRIPTION
added new set of examples:
- [checkbox-group-input](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples-p2/examples/inputs/checkbox-group-input)
- [field-array-input](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples-p2/examples/inputs/field-array-input)
- [mui-date-picker-input](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples-p2/examples/inputs/mui-date-picker-input)
- [mui-multi-select-input](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples-p2/examples/inputs/mui-multi-select-input)
- [radio-group-input](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples-p2/examples/inputs/radio-group-input)
- [select-input](https://codesandbox.io/s/github/VirtusLab/formts/tree/docs/codesandbox-examples-p2/examples/inputs/select-input)

also added filtering out of `""` from options dictionary of choice field