### PR TITLE
fix(core): parsing date instance initial value

### DIFF
--- a/src/core/helpers/create-initial-values.spec.ts
+++ b/src/core/helpers/create-initial-values.spec.ts
@@ -112,7 +112,7 @@ describe("createInitialValues", () => {
 
   it("for date field", () => {
     const schema = createFormSchema(fields => ({
-      dateField: fields.instanceOf(Date),
+      dateField: fields.date(),
     }));
 
     expect(

--- a/src/core/helpers/create-initial-values.spec.ts
+++ b/src/core/helpers/create-initial-values.spec.ts
@@ -109,4 +109,14 @@ describe("createInitialValues", () => {
       arr: [{ two: [10] }],
     });
   });
+
+  it("for date field", () => {
+    const schema = createFormSchema(fields => ({
+      dateField: fields.instanceOf(Date),
+    }));
+
+    expect(
+      createInitialValues(schema, { dateField: Date.UTC(2021, 1, 1) })
+    ).toEqual({ dateField: Date.UTC(2021, 1, 1) });
+  });
 });

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -103,7 +103,8 @@ export const deepMerge = <T extends object>(
       toMerge !== undefined
         ? Array.isArray(toMerge) ||
           typeof toMerge !== "object" ||
-          toMerge === null
+          toMerge === null ||
+          toMerge instanceof Date
           ? toMerge
           : deepMerge(value, toMerge as any)
         : value;


### PR DESCRIPTION
Fixed bug, where `Date` passed in `initialValue` raised TypeError.