### PR TITLE
build: expose validators as package submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 node_modules
 node_modules_
 dist
+__dist
+__src
 *.log
 .vscode
 .idea
 .DS_Store
+validators

--- a/examples/advanced-forms/change-password-form/src/example.tsx
+++ b/examples/advanced-forms/change-password-form/src/example.tsx
@@ -1,5 +1,4 @@
 import {
-  BaseErrors,
   createFormSchema,
   createFormValidator,
   FormProvider,
@@ -7,8 +6,8 @@ import {
   useFormController,
   useFormHandle,
   useFormValues,
-  validators as v,
 } from "@virtuslab/formts";
+import * as V from "@virtuslab/formts/validators";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -26,16 +25,16 @@ const Schema = createFormSchema(
 );
 
 type FormError =
-  | BaseErrors.Required
-  | v.ErrorType<typeof passwordMultiValidator>
+  | V.Errors.Required
+  | V.ErrorType<typeof passwordMultiValidator>
   | { code: "confirmPassMismatch" }
   | { code: "invalidCurrentPass" };
 
-const passwordMultiValidator = v.combine(
+const passwordMultiValidator = V.combine(
   [
-    v.minLength(MIN_PASS_LEN),
-    v.hasLowerCaseChar(),
-    v.hasUpperCaseChar(),
+    V.minLength(MIN_PASS_LEN),
+    V.hasLowerCaseChar(),
+    V.hasUpperCaseChar(),
     val => (val.includes("42") ? null : ({ code: "hasTheAnswer" } as const)),
   ],
   ([minLen, lowerChar, upperChar, hasTheAnswer]) => ({
@@ -50,11 +49,11 @@ const passwordMultiValidator = v.combine(
 );
 
 const validator = createFormValidator(Schema, validate => [
-  validate(Schema.currentPass, v.required()),
+  validate(Schema.currentPass, V.required()),
 
   validate(Schema.newPass, passwordMultiValidator),
 
-  validate(Schema.newPassConfirm, v.required()),
+  validate(Schema.newPassConfirm, V.required()),
   validate({
     field: Schema.newPassConfirm,
     dependencies: [Schema.newPass],
@@ -103,7 +102,7 @@ const NewPassInput: React.FC = () => {
   const field = useField(Schema.newPass);
 
   const renderRequirement = (
-    rule: keyof v.ErrorType<typeof passwordMultiValidator>["rules"],
+    rule: keyof V.ErrorType<typeof passwordMultiValidator>["rules"],
     label: string
   ) => {
     const ruleError =

--- a/examples/basic-forms/3-basic-form-validation/src/example.tsx
+++ b/examples/basic-forms/3-basic-form-validation/src/example.tsx
@@ -8,8 +8,8 @@ import {
   useField,
   useFormValues,
   FormProvider,
-  validators,
 } from "@virtuslab/formts";
+import { withError, required, minValue } from "@virtuslab/formts/validators";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -27,13 +27,13 @@ const validator = createFormValidator(Schema, validate => [
   validate(
     Schema.name,
     // you can mix built-in validators with custom functions
-    validators.withError(validators.required(), "Required"),
+    withError(required(), "Required"),
     val => (val.length > 10 ? "Name must be max 10 characters long" : null)
   ),
   validate(
     Schema.age,
-    validators.withError(validators.required(), "Required"),
-    validators.withError(validators.minValue(18), "Age must be at least 18")
+    withError(required(), "Required"),
+    withError(minValue(18), "Age must be at least 18")
   ),
 ]);
 

--- a/examples/basic-forms/4-basic-form-mui/src/example.tsx
+++ b/examples/basic-forms/4-basic-form-mui/src/example.tsx
@@ -9,8 +9,8 @@ import {
   useField,
   useFormValues,
   FormProvider,
-  validators,
 } from "@virtuslab/formts";
+import { withError, required, minValue } from "@virtuslab/formts/validators";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -28,13 +28,13 @@ const validator = createFormValidator(Schema, validate => [
   validate(
     Schema.name,
     // you can mix built-in validators with custom functions
-    validators.withError(validators.required(), "Required"),
+    withError(required(), "Required"),
     val => (val.length > 10 ? "Name must be max 10 characters long" : null)
   ),
   validate(
     Schema.age,
-    validators.withError(validators.required(), "Required"),
-    validators.withError(validators.minValue(18), "Age must be at least 18")
+    withError(required(), "Required"),
+    withError(minValue(18), "Age must be at least 18")
   ),
 ]);
 

--- a/examples/basic-forms/5-complex-form-mui/src/example.tsx
+++ b/examples/basic-forms/5-complex-form-mui/src/example.tsx
@@ -17,8 +17,8 @@ import {
   useField,
   useFormValues,
   FormProvider,
-  validators,
 } from "@virtuslab/formts";
+import { withError, required } from "@virtuslab/formts/validators";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -60,7 +60,7 @@ const validator = createFormValidator(Schema, validate => [
   validate(
     Schema.name,
     // you can mix built-in validators with custom functions
-    validators.withError(validators.required(), "Required"),
+    withError(required(), "Required"),
     val => (val.length > 10 ? "Name must be max 10 characters long" : null)
   ),
   validate({

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "author": "Mikołaj Klaman <mklaman@virtuslab.com>",
   "license": "MIT",
   "private": false,
-  "main": "dist/index.js",
-  "module": "dist/formts.esm.js",
-  "typings": "dist/index.d.ts",
+  "main": "__dist/index.js",
+  "module": "__dist/esm/index.js",
+  "typings": "__dist/index.d.ts",
   "side-effects": false,
   "files": [
-    "dist",
-    "src"
+    "__dist",
+    "__src",
+    "validators"
   ],
   "keywords": [
     "react",
@@ -22,12 +23,14 @@
   ],
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build",
+    "build": "tsdx build && sh ./scripts/postbuild.sh",
     "test": "tsdx test",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
+    "prepare": "yarn build",
     "size": "size-limit",
     "analyze": "size-limit --why",
+    "prepack": "sh ./scripts/prepack.sh",
+    "postpack": "sh ./scripts/postpack.sh",
     "release": "standard-version --releaseCommitMessageFormat \"chore(release): {{currentTag}} [ci skip]\""
   },
   "husky": {

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -1,0 +1,13 @@
+# --- 1. rename dist  into __dist to signal that it is not intended for imports
+rm -rf ./__dist
+
+mv ./dist ./__dist
+
+# --- 2. prepare root validators dir to enable imports: 'import {} from "@virtuslab/formts/validators"'
+
+mkdir ./validators
+
+# 'dist/esm/index2' is a chunk created for 'src/validators/index.ts'
+echo 'export * from "../__dist/esm/index2";' > ./validators/index.js
+
+echo 'export * from "../__dist/validators";' > ./validators/index.d.ts

--- a/scripts/postpack.sh
+++ b/scripts/postpack.sh
@@ -1,0 +1,3 @@
+# --- cleanup directories created by prepack.sh
+
+rm -rf ./__src

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,0 +1,6 @@
+# --- copy src into __src to signal that it is not intended for imports
+
+rm -rf ./__src
+
+cp -r ./src ./__src
+

--- a/src/core/builders/create-form-validator.spec.ts
+++ b/src/core/builders/create-form-validator.spec.ts
@@ -1,7 +1,7 @@
 import { assert, IsExact } from "conditional-type-checks";
 
 import { Task } from "../../utils/task";
-import { validators } from "../../validators";
+import * as validators from "../../validators";
 import { FieldDescriptor } from "../types/field-descriptor";
 import { FormValidator } from "../types/form-validator";
 import { impl } from "../types/type-mapper-util";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
 export * from "./core";
-export * from "./validators";

--- a/src/validators/base-errors.ts
+++ b/src/validators/base-errors.ts
@@ -1,23 +1,25 @@
 import { Primitive } from "../utils/utility-types";
 
-export type Required = { code: "required" };
-export type OneOf = { code: "oneOf"; allowedValues: Primitive[] };
+export namespace Errors {
+  export type Required = { code: "required" };
+  export type OneOf = { code: "oneOf"; allowedValues: Primitive[] };
 
-export type Integer = { code: "integer" };
-export type MinValue = { code: "minValue"; min: number };
-export type MaxValue = { code: "maxValue"; max: number };
-export type GreaterThan = { code: "greaterThan"; threshold: number };
-export type LesserThan = { code: "lesserThan"; threshold: number };
+  export type Integer = { code: "integer" };
+  export type MinValue = { code: "minValue"; min: number };
+  export type MaxValue = { code: "maxValue"; max: number };
+  export type GreaterThan = { code: "greaterThan"; threshold: number };
+  export type LesserThan = { code: "lesserThan"; threshold: number };
 
-export type Pattern = { code: "pattern"; regex: RegExp };
-export type HasSpecialChar = { code: "hasSpecialChar" };
-export type HasUpperCaseChar = { code: "hasUpperCaseChar" };
-export type HasLowerCaseChar = { code: "hasLowerCaseChar" };
+  export type Pattern = { code: "pattern"; regex: RegExp };
+  export type HasSpecialChar = { code: "hasSpecialChar" };
+  export type HasUpperCaseChar = { code: "hasUpperCaseChar" };
+  export type HasLowerCaseChar = { code: "hasLowerCaseChar" };
 
-export type MinLength = { code: "minLength"; min: number };
-export type MaxLength = { code: "maxLength"; max: number };
-export type ExactLength = { code: "exactLength"; expected: number };
+  export type MinLength = { code: "minLength"; min: number };
+  export type MaxLength = { code: "maxLength"; max: number };
+  export type ExactLength = { code: "exactLength"; expected: number };
 
-export type ValidDate = { code: "validDate" };
-export type MinDate = { code: "minDate"; min: Date };
-export type MaxDate = { code: "maxDate"; max: Date };
+  export type ValidDate = { code: "validDate" };
+  export type MinDate = { code: "minDate"; min: Date };
+  export type MaxDate = { code: "maxDate"; max: Date };
+}

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,4 +1,2 @@
-// TODO: tree-shaking compatible way of importing validators
-export * as validators from "./validators";
-
-export * as BaseErrors from "./base-errors";
+export * from "./validators";
+export * from "./base-errors";

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -4,7 +4,7 @@ import { Validator } from "../core";
 import { Task } from "../utils/task";
 import { Primitive, WidenType } from "../utils/utility-types";
 
-import * as BaseErrors from "./base-errors";
+import { Errors } from "./base-errors";
 
 // utils
 
@@ -165,10 +165,7 @@ export const combine: Combine = <T, E>(
 // general
 
 /** Checks if field value is present */
-export const required = (): Validator.Sync<
-  unknown,
-  BaseErrors.Required
-> => val =>
+export const required = (): Validator.Sync<unknown, Errors.Required> => val =>
   val == null || val === "" || val === false ? { code: "required" } : null;
 
 /**
@@ -187,39 +184,37 @@ export const optional = () => (val: unknown): null => {
 /** checks if value is one of provided values */
 export const oneOf = <V extends Primitive>(
   ...allowedValues: V[]
-): Validator.Sync<WidenType<V>, BaseErrors.OneOf> => val =>
+): Validator.Sync<WidenType<V>, Errors.OneOf> => val =>
   allowedValues.includes(val as V) ? null : { code: "oneOf", allowedValues };
 
 // numbers
 
 /** checks if value is integer number */
-export const integer = (): Validator.Sync<
-  number | "",
-  BaseErrors.Integer
-> => num => (Number.isInteger(num) ? null : { code: "integer" });
+export const integer = (): Validator.Sync<number | "", Errors.Integer> => num =>
+  Number.isInteger(num) ? null : { code: "integer" };
 
 /** checks number value against provided minimum */
 export const minValue = (
   min: number
-): Validator.Sync<number | "", BaseErrors.MinValue> => num =>
+): Validator.Sync<number | "", Errors.MinValue> => num =>
   num === "" || num < min ? { code: "minValue", min } : null;
 
 /** checks number value against provided maximum */
 export const maxValue = (
   max: number
-): Validator.Sync<number | "", BaseErrors.MaxValue> => num =>
+): Validator.Sync<number | "", Errors.MaxValue> => num =>
   num === "" || num > max ? { code: "maxValue", max } : null;
 
 /** checks if value is a number greater than provided value */
 export const greaterThan = (
   threshold: number
-): Validator.Sync<number | "", BaseErrors.GreaterThan> => num =>
+): Validator.Sync<number | "", Errors.GreaterThan> => num =>
   num === "" || num <= threshold ? { code: "greaterThan", threshold } : null;
 
 /** checks if value is a number smaller than provided value */
 export const lesserThan = (
   threshold: number
-): Validator.Sync<number | "", BaseErrors.LesserThan> => num =>
+): Validator.Sync<number | "", Errors.LesserThan> => num =>
   num === "" || num >= threshold ? { code: "lesserThan", threshold } : null;
 
 // strings
@@ -227,20 +222,20 @@ export const lesserThan = (
 /** checks pattern exists in string value using `RegExp.test` function */
 export const pattern = (
   regex: RegExp
-): Validator.Sync<string, BaseErrors.Pattern> => string =>
+): Validator.Sync<string, Errors.Pattern> => string =>
   regex.test(string) ? null : { code: "pattern", regex };
 
 /** checks if string value contains an uppercase character */
 export const hasUpperCaseChar = (): Validator.Sync<
   string,
-  BaseErrors.HasUpperCaseChar
+  Errors.HasUpperCaseChar
 > => (val: string) =>
   /[A-Z]/.test(val) ? null : { code: "hasUpperCaseChar" as const };
 
 /** checks if string value contains an lowercase character */
 export const hasLowerCaseChar = (): Validator.Sync<
   string,
-  BaseErrors.HasLowerCaseChar
+  Errors.HasLowerCaseChar
 > => (val: string) =>
   /[a-z]/.test(val) ? null : { code: "hasLowerCaseChar" as const };
 
@@ -249,19 +244,19 @@ export const hasLowerCaseChar = (): Validator.Sync<
 /** checks length of string or array value against provided minimum */
 export const minLength = (
   min: number
-): Validator.Sync<{ length: number }, BaseErrors.MinLength> => val =>
+): Validator.Sync<{ length: number }, Errors.MinLength> => val =>
   val.length < min ? { code: "minLength", min } : null;
 
 /** checks length of string or array value against provided maximum */
 export const maxLength = (
   max: number
-): Validator.Sync<{ length: number }, BaseErrors.MaxLength> => val =>
+): Validator.Sync<{ length: number }, Errors.MaxLength> => val =>
   val.length > max ? { code: "maxLength", max } : null;
 
 /** checks if length of string or array value is equal to expected */
 export const exactLength = (
   expected: number
-): Validator.Sync<{ length: number }, BaseErrors.ExactLength> => val =>
+): Validator.Sync<{ length: number }, Errors.ExactLength> => val =>
   val.length !== expected ? { code: "exactLength", expected } : null;
 
 // dates
@@ -269,7 +264,7 @@ export const exactLength = (
 /** compares date value against provided minimum */
 export const minDate = (
   min: Date
-): Validator.Sync<Date | null, BaseErrors.MinDate> => date =>
+): Validator.Sync<Date | null, Errors.MinDate> => date =>
   date == null || Number.isNaN(date.valueOf()) || date.valueOf() < min.valueOf()
     ? { code: "minDate", min }
     : null;
@@ -277,7 +272,7 @@ export const minDate = (
 /** compares date value against provided maximum */
 export const maxDate = (
   max: Date
-): Validator.Sync<Date | null, BaseErrors.MaxDate> => date =>
+): Validator.Sync<Date | null, Errors.MaxDate> => date =>
   date == null || Number.isNaN(date.valueOf()) || date.valueOf() > max.valueOf()
     ? { code: "maxDate", max }
     : null;

--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -1,0 +1,32 @@
+// see: https://github.com/formium/tsdx#rollup
+
+// TODO: track https://github.com/formium/tsdx/issues/961 for possible better solution
+
+const path = require("path");
+
+const relativePath = p => path.join(__dirname, p);
+
+module.exports = {
+  rollup(config, options) {
+    if (options.format === "esm") {
+      // we use this to output separate chunk for /src/validators
+      // see: https://stackoverflow.com/a/65173887
+      return {
+        ...config,
+        input: [
+          relativePath("src/index.ts"),
+          relativePath("src/validators/index.ts"),
+        ],
+        output: {
+          ...config.output,
+          file: undefined,
+          dir: relativePath("dist/esm"),
+          preserveModules: true,
+          preserveModulesRoot: relativePath("src"),
+        },
+      };
+    } else {
+      return config;
+    }
+  },
+};


### PR DESCRIPTION

<img width="977" alt="Screenshot 2021-03-12 at 04 16 36" src="https://user-images.githubusercontent.com/12655670/110886961-bde7ad80-82e9-11eb-8884-e114ad5e4372.png">

mess with rollup config based on https://stackoverflow.com/a/65173887 and use some bash scripts to prepare desired npm package.

closes #73 
